### PR TITLE
Investigate cache miss in dataloaders

### DIFF
--- a/loaders/loader.go
+++ b/loaders/loader.go
@@ -11,7 +11,7 @@ import (
 type contextKey string
 
 const (
-	filmLoaderKey contextKey = "film_loader"
+	filmLoaderKey   contextKey = "film_loader"
 	personLoaderKey contextKey = "person_loader"
 )
 
@@ -30,7 +30,7 @@ func (c *Collection) Attach(ctx context.Context) context.Context {
 func Initialize(client *swapi.Client) *Collection {
 	return &Collection{
 		lookup: map[contextKey]interface{}{
-			filmLoaderKey: newFilmLoader(client),
+			filmLoaderKey:   newFilmLoader(client),
 			personLoaderKey: newPersonLoader(client),
 		},
 	}
@@ -55,13 +55,11 @@ func GetPersonLoader(ctx context.Context) *PersonLoader {
 func newFilmLoader(client *swapi.Client) *FilmLoader {
 	return NewFilmLoader(FilmLoaderConfig{
 		Fetch: func(ids []int) ([]*swapi.Film, []error) {
-			log.Print("Total films: ", len(ids))
-
 			var (
-				n = len(ids)
-				films = make([]*swapi.Film, n)
+				n      = len(ids)
+				films  = make([]*swapi.Film, n)
 				errors = make([]error, n)
-				wg sync.WaitGroup
+				wg     sync.WaitGroup
 			)
 
 			wg.Add(n)
@@ -92,10 +90,10 @@ func newPersonLoader(client *swapi.Client) *PersonLoader {
 	return NewPersonLoader(PersonLoaderConfig{
 		Fetch: func(ids []int) ([]*swapi.Person, []error) {
 			var (
-				n = len(ids)
+				n      = len(ids)
 				people = make([]*swapi.Person, n)
-				errs = make([]error, n)
-				wg sync.WaitGroup
+				errs   = make([]error, n)
+				wg     sync.WaitGroup
 			)
 
 			wg.Add(n)

--- a/resolver/starwars/film.go
+++ b/resolver/starwars/film.go
@@ -33,10 +33,28 @@ func (r *filmResolver) Characters(ctx context.Context, f *swapi.Film) ([]*swapi.
 		urls = append(urls, string(url))
 	}
 
-	return getCharacters(ctx, urls)
+	characters, err := getCharacters(ctx, urls)
+	if err != nil {
+		return nil, err
+	}
+
+	if isFieldRequested(ctx, "films") && len(characters) > 0 {
+		urls := make([]string, 0, len(characters) * len(characters[0].FilmURLs))
+		for _, character := range characters {
+			for _, url := range character.FilmURLs {
+				urls = append(urls, string(url))
+			}
+		}
+
+		// Load and Prime cache
+		// NOTE: This is blocking call
+		getFilms(ctx, urls)
+	}
+
+	return characters, err
 }
 
-func getCharacters(ctx context.Context, urls []string) ([]*swapi.Person, error) {
+func getFilms(ctx context.Context, urls []string) ([]*swapi.Film, error) {
 	entry := middlewares.GetLogEntry(ctx)
 	ids := make([]int, 0, len(urls))
 
@@ -51,10 +69,10 @@ func getCharacters(ctx context.Context, urls []string) ([]*swapi.Person, error) 
 		ids = append(ids, id)
 	}
 
-	characters, errs := loaders.GetPersonLoader(ctx).LoadAll(ids)
+	films, errs := loaders.GetFilmLoader(ctx).LoadAll(ids)
 	if len(errs) > 0 && errs[0] != nil {
-		return nil, errs[0]
+		return nil, errors.NewAPIError(errs[0])
 	}
 
-	return characters, nil
+	return films, nil
 }

--- a/resolver/starwars/film.go
+++ b/resolver/starwars/film.go
@@ -39,11 +39,16 @@ func (r *filmResolver) Characters(ctx context.Context, f *swapi.Film) ([]*swapi.
 	}
 
 	if isFieldRequested(ctx, "films") && len(characters) > 0 {
-		urls := make([]string, 0, len(characters) * len(characters[0].FilmURLs))
+		urlMap := make(map[string]interface{}, 0)
 		for _, character := range characters {
 			for _, url := range character.FilmURLs {
-				urls = append(urls, string(url))
+				urlMap[string(url)] = nil
 			}
+		}
+
+		urls := make([]string, 0, len(urlMap))
+		for url, _ := range urlMap {
+			urls = append(urls, url)
 		}
 
 		// Load and Prime cache

--- a/resolver/starwars/film.go
+++ b/resolver/starwars/film.go
@@ -8,7 +8,7 @@ import (
 	"gqlgen-starwars/errors"
 	"gqlgen-starwars/loaders"
 	"gqlgen-starwars/server/middlewares"
-	swapi2 "gqlgen-starwars/swapi"
+	swapihelper "gqlgen-starwars/swapi"
 )
 
 type filmResolver struct {
@@ -28,11 +28,20 @@ func (*filmResolver) Name(ctx context.Context, f *swapi.Film) (string, error) {
 }
 
 func (r *filmResolver) Characters(ctx context.Context, f *swapi.Film) ([]*swapi.Person, error) {
-	entry := middlewares.GetLogEntry(ctx)
-	ids := make([]int, 0, len(f.CharacterURLs))
-
+	urls := make([]string, 0, len(f.CharacterURLs))
 	for _, url := range f.CharacterURLs {
-		id, err := swapi2.ResourceId(string(url))
+		urls = append(urls, string(url))
+	}
+
+	return getCharacters(ctx, urls)
+}
+
+func getCharacters(ctx context.Context, urls []string) ([]*swapi.Person, error) {
+	entry := middlewares.GetLogEntry(ctx)
+	ids := make([]int, 0, len(urls))
+
+	for _, url := range urls {
+		id, err := swapihelper.ResourceId(url)
 		if err != nil {
 			entry.WithError(err).Error("Failed to parse id from url")
 

--- a/resolver/starwars/person.go
+++ b/resolver/starwars/person.go
@@ -3,12 +3,13 @@ package starwars
 import (
 	"context"
 
+	"github.com/99designs/gqlgen/graphql"
 	"github.com/peterhellberg/swapi"
 
 	"gqlgen-starwars/errors"
 	"gqlgen-starwars/loaders"
 	"gqlgen-starwars/server/middlewares"
-	swapi2 "gqlgen-starwars/swapi"
+	swapihelper "gqlgen-starwars/swapi"
 )
 
 type personResolver struct {
@@ -27,8 +28,10 @@ func (r *personResolver) Films(ctx context.Context, p *swapi.Person) ([]*swapi.F
 	entry := middlewares.GetLogEntry(ctx)
 	ids := make([]int, 0, len(p.FilmURLs))
 
+	entry.Debugf("Resolving films for: %s", p.Name)
+
 	for _, url := range p.FilmURLs {
-		id, err := swapi2.ResourceId(string(url))
+		id, err := swapihelper.ResourceId(string(url))
 		if err != nil {
 			entry.WithError(err).Error("Failed to parse id from url")
 
@@ -43,5 +46,29 @@ func (r *personResolver) Films(ctx context.Context, p *swapi.Person) ([]*swapi.F
 		return nil, errs[0]
 	}
 
+	if isFieldRequested(ctx, "characters") && len(films) > 0 {
+		urls := make([]string, 0, len(films) * len(films[0].CharacterURLs))
+
+		for _, film := range films {
+			for _, url := range film.CharacterURLs {
+				urls = append(urls, string(url))
+			}
+		}
+
+		// Load and Prime cache for characters
+		// NOTE: This will block until all characters are loaded.
+		getCharacters(ctx, urls)
+	}
+
 	return films, nil
+}
+
+func isFieldRequested(ctx context.Context, field string) bool {
+	for _, f := range graphql.CollectAllFields(ctx) {
+		if f == field {
+			return true
+		}
+	}
+
+	return false
 }

--- a/resolver/starwars/person.go
+++ b/resolver/starwars/person.go
@@ -35,12 +35,16 @@ func (r *personResolver) Films(ctx context.Context, p *swapi.Person) ([]*swapi.F
 	}
 
 	if isFieldRequested(ctx, "characters") && len(films) > 0 {
-		urls := make([]string, 0, len(films) * len(films[0].CharacterURLs))
-
+		urlMap := make(map[string]interface{}, 0)
 		for _, film := range films {
 			for _, url := range film.CharacterURLs {
-				urls = append(urls, string(url))
+				urlMap[string(url)] = nil
 			}
+		}
+
+		urls := make([]string, 0, len(urlMap))
+		for url, _ := range urlMap {
+			urls = append(urls, url)
 		}
 
 		// Load and Prime cache for characters

--- a/resolver/starwars/resource.go
+++ b/resolver/starwars/resource.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/99designs/gqlgen/graphql"
+
 	"gqlgen-starwars/errors"
 	"gqlgen-starwars/server/middlewares"
 	"gqlgen-starwars/swapi"
@@ -19,4 +21,14 @@ func ID(ctx context.Context, url string) (string, error) {
 	}
 
 	return strconv.Itoa(id), nil
+}
+
+func isFieldRequested(ctx context.Context, field string) bool {
+	for _, f := range graphql.CollectAllFields(ctx) {
+		if f == field {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
Query:

```
query {
  character(id: "8") {
    id, name
    films {
      id, name
      characters {
        id, name
        films { id, name } } }
  }
}
```

NOTE: This could be due to cache being localized for a resolver.